### PR TITLE
fix: implement intelligent wall-following to prevent spinning

### DIFF
--- a/src/WallFollowingController.cpp
+++ b/src/WallFollowingController.cpp
@@ -8,18 +8,26 @@ void WallFollowingController::execute(float leftDist, float rightDist) {
   int rightSpeed = SEARCH_SPEED;
 
   bool leftWall = (leftDist > 0 && leftDist < WALL_DETECT_THRESHOLD);
+  bool rightWall = (rightDist > 0 && rightDist < WALL_DETECT_THRESHOLD);
 
   if (leftWall) {
-    // "Left-hand rule": always prioritize following the left wall.
+    // Case 1: Left wall is detected. Follow it. (Highest priority)
     Serial.println("State: WALL_FOLLOW_L");
     float perp_dist_L = leftDist * SIN_26_5_DEG;
     float error = WALL_TARGET_DISTANCE - perp_dist_L;
     int correction = (int)(WALL_FOLLOW_KP * error);
     leftSpeed -= correction;
     rightSpeed += correction;
+  } else if (rightWall) {
+    // Case 2: No left wall, but there is a right wall.
+    // Move forward and curve gently to the left to eventually find a wall on the left.
+    Serial.println("State: SEARCH (CURVE LEFT)");
+    leftSpeed = SEARCH_SPEED * 0.7; // Move left wheel slower to curve left
+    rightSpeed = SEARCH_SPEED;
   } else {
-    // No left wall found, turn right to find one.
-    Serial.println("State: SEARCH (FIND WALL)");
+    // Case 3: No walls on either side.
+    // Turn on the spot to find a wall.
+    Serial.println("State: SEARCH (SPIN RIGHT)");
     leftSpeed = TURN_SPEED;
     rightSpeed = -TURN_SPEED; // Turn right
   }


### PR DESCRIPTION
This commit fixes a bug where the simple "left-hand rule" logic would cause the robot to spin on the spot if no left wall was detected, even if a right wall was present.

The `WallFollowingController`'s `execute` method is updated with a more nuanced 3-state logic:
1.  If a left wall exists, follow it.
2.  If no left wall but a right wall exists, curve gently left while moving forward.
3.  If no walls exist, spin to find one.

This prevents unnecessary spinning and creates a more robust exploration algorithm.